### PR TITLE
General tests for spectra

### DIFF
--- a/pseudospectral/spectra/derivative_1D.py
+++ b/pseudospectral/spectra/derivative_1D.py
@@ -45,16 +45,17 @@ class Derivative1D:
             return input_vector
         
         # Perform the discrete Fast Fourier transform to go from real to spectral space
-        elif input_space == 'real' and output_space == 'spectral':
-            return scipy.fft.fft(input_vector) / self.num_lattice_points
-        
-        # Perform the inverse discrete Fast Fourier transform to go from spectral to real space
-        elif input_space == 'spectral' and output_space == 'real':
-            return scipy.fft.ifft(input_vector) * self.num_lattice_points
-        
-        else:
-            raise ValueError(f"Unsupported space transformation from {input_space} to {output_space}.")
+        elif input_space == "real" and output_space == "spectral":
+            return scipy.fft.fft(input_vector, norm="ortho")
 
+        # Perform the inverse discrete Fast Fourier transform to go from spectral to real space
+        elif input_space == "spectral" and output_space == "real":
+            return scipy.fft.ifft(input_vector, norm="ortho")
+
+        else:
+            raise ValueError(
+                f"Unsupported space transformation from {input_space} to {output_space}."
+            )
 
     def lattice(self, output_space):
         """
@@ -67,6 +68,7 @@ class Derivative1D:
         else:
             raise ValueError("Unsupported output space.")
 
-    def scalar_product(self, lhs, rhs):
+    def scalar_product(self, lhs, rhs, input_space="real"):
         # for this case the quadrature (and thereby the scalar product) is trivial
+        # also, it's the same for both spaces
         return lhs.T.conjugate() @ rhs

--- a/pseudospectral/spectra/derivative_1D.py
+++ b/pseudospectral/spectra/derivative_1D.py
@@ -68,9 +68,9 @@ class Derivative1D:
         else:
             raise ValueError("Unsupported output space.")
 
-    def scalar_product(self, lhs, rhs, input_space="real"):
+    def scalar_product(self, lhs, rhs, input_basis="real"):
         """
-        Compute <lhs, rhs> both being represented as coefficients in the `input_space` basis.
+        Compute <lhs, rhs> both being represented as coefficients in the `input_basis`.
         If multi-dimensional input is given,
         the last dimension gives the individual vector's entries
         while the first dimensions (all others) are interpreted as enumerating the multiple vectors.

--- a/pseudospectral/spectra/derivative_1D.py
+++ b/pseudospectral/spectra/derivative_1D.py
@@ -21,8 +21,9 @@ class Derivative1D:
         """
         Private function to return the eigenfunctions of the 1D derivative operator i.e. exp(ikx)
         """
-        return lambda x: np.exp(self.eigenvalues[index] * x)
-
+        return lambda x: np.exp(self.eigenvalues[index] * x) / np.sqrt(
+            self.num_lattice_points
+        )
 
     def _eigenvalues(self):
         """
@@ -65,3 +66,7 @@ class Derivative1D:
             return 2 * np.pi * np.arange(self.num_lattice_points) / self.L
         else:
             raise ValueError("Unsupported output space.")
+
+    def scalar_product(self, lhs, rhs):
+        # for this case the quadrature (and thereby the scalar product) is trivial
+        return lhs.T.conjugate() @ rhs

--- a/pseudospectral/spectra/derivative_1D.py
+++ b/pseudospectral/spectra/derivative_1D.py
@@ -61,14 +61,21 @@ class Derivative1D:
         """
         Return the lattice of the Dirac operator as per the given output space.
         """
-        if output_space == 'real':
+        if output_space == "real":
             return np.linspace(0, self.L, self.num_lattice_points, endpoint=False)
-        elif output_space == 'spectral':
+        elif output_space == "spectral":
             return 2 * np.pi * np.arange(self.num_lattice_points) / self.L
         else:
             raise ValueError("Unsupported output space.")
 
     def scalar_product(self, lhs, rhs, input_space="real"):
+        """
+        Compute <lhs, rhs> both being represented as coefficients in the `input_space` basis.
+        If multi-dimensional input is given,
+        the last dimension gives the individual vector's entries
+        while the first dimensions (all others) are interpreted as enumerating the multiple vectors.
+        """
         # for this case the quadrature (and thereby the scalar product) is trivial
         # also, it's the same for both spaces
-        return lhs.T.conjugate() @ rhs
+        # the unexpected ordering takes care of the indexing convention mentioned in the docstring
+        return rhs @ lhs.transpose(-1, 0).conjugate()

--- a/pseudospectral/spectra/derivative_1D.py
+++ b/pseudospectral/spectra/derivative_1D.py
@@ -75,7 +75,13 @@ class Derivative1D:
         the last dimension gives the individual vector's entries
         while the first dimensions (all others) are interpreted as enumerating the multiple vectors.
         """
-        # for this case the quadrature (and thereby the scalar product) is trivial
-        # also, it's the same for both spaces
-        # the unexpected ordering takes care of the indexing convention mentioned in the docstring
-        return rhs @ lhs.transpose(-1, 0).conjugate()
+        # For this case the quadrature (and thereby the scalar product) is trivial.
+        # Also, it's the same for both spaces.
+        #
+        # The unexpected ordering takes care of the indexing convention mentioned in the docstring:
+        # We are considering lhs, rhs as row vectors in a matrix (or higher-dimensional object).
+        # For this reason, we must commute them with respect to the normal interpretation as column vectors
+        # (that's why rhs @ lhs and not lhs @ rhs).
+        # Furthermore, the @ operator interpretes multi-dimensional objects as "stacks of matrices"
+        # and accordingly acts on the LAST index of the first but the SECOND TO LAST index of the second.
+        return rhs @ lhs.transpose(-1, -2).conjugate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,16 +3,12 @@ name = "pseudospectral"
 version = "0.1.0"
 license = { file = "LICENSE" }
 authors = [
-    {name = "Mayank Goel", email = "mayank.goel447@gmail.com"},
-    {name = "Julian Lenz", email = "j.lenz@hzdr.de"}
+  { name = "Mayank Goel", email = "mayank.goel447@gmail.com" },
+  { name = "Julian Lenz", email = "j.lenz@hzdr.de" },
 ]
 description = "A Python package for pseudospectral discretization of the Dirac operator."
 keywords = ["pseudospectral", "spectral methods", "Dirac Operator"]
 readme = "README.md"
 
 requires-python = ">=3.12"
-dependencies = [
-    "numpy==2.0.0",
-    "scipy==1.14.0",
-    "matplotlib==3.9.0",
-]
+dependencies = ["numpy==2.0.0", "scipy==1.14.0", "matplotlib==3.9.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pseudospectral"
 version = "0.1.0"
-license = "GNU General Public License v3.0"
+license = { file = "LICENSE" }
 authors = [
     {name = "Mayank Goel", email = "mayank.goel447@gmail.com"},
     {name = "Julian Lenz", email = "j.lenz@hzdr.de"}

--- a/test/test_spectra.py
+++ b/test/test_spectra.py
@@ -4,8 +4,9 @@ import pytest
 
 TEST_DATA = [
     (Derivative1D, {"num_lattice_points": 3}),
-    (Derivative1D, {"num_lattice_points": 11}),
     (Derivative1D, {"num_lattice_points": 101}),
+    (Derivative1D, {"num_lattice_points": 3, "L": 3}),
+    (Derivative1D, {"num_lattice_points": 101, "L": 42}),
 ]
 
 

--- a/test/test_spectra.py
+++ b/test/test_spectra.py
@@ -37,3 +37,26 @@ def test_back_and_forth_transform_is_identity(Spectrum, spectral_config):
         ),
         eigenfunctions,
     )
+
+
+@pytest.mark.parametrize(["Spectrum", "spectral_config"], TEST_DATA)
+def test_unitary_transform(Spectrum, spectral_config):
+    spectrum = Spectrum(**spectral_config)
+    eigenfunctions = spectrum.eigenfunction(
+        np.arange(spectral_config["num_lattice_points"]).reshape(-1, 1)
+    )(spectrum.lattice(output_space="real"))
+
+    after_transform = spectrum.transform(
+        eigenfunctions, input_space="real", output_space="spectral"
+    )
+
+    # It suffices to test the forward transformation because if the forward
+    # transformation is unitary and the other test ensures that back and forth
+    # transformation is an identity, we can conclude that the inverse
+    # transformation is also unitary.
+    assert np.allclose(
+        spectrum.scalar_product(
+            after_transform, after_transform, input_space="spectral"
+        ),
+        spectrum.scalar_product(eigenfunctions, eigenfunctions),
+    )

--- a/test/test_spectra.py
+++ b/test/test_spectra.py
@@ -57,7 +57,7 @@ def test_unitary_transform(Spectrum, spectral_config):
     # transformation is also unitary.
     assert np.allclose(
         spectrum.scalar_product(
-            after_transform, after_transform, input_space="spectral"
+            after_transform, after_transform, input_basis="spectral"
         ),
         spectrum.scalar_product(eigenfunctions, eigenfunctions),
     )

--- a/test/test_spectra.py
+++ b/test/test_spectra.py
@@ -1,0 +1,39 @@
+from pseudospectral import Derivative1D
+import numpy as np
+import pytest
+
+TEST_DATA = [
+    (Derivative1D, {"num_lattice_points": 3}),
+    (Derivative1D, {"num_lattice_points": 11}),
+    (Derivative1D, {"num_lattice_points": 101}),
+]
+
+
+@pytest.mark.parametrize(["Spectrum", "spectral_config"], TEST_DATA)
+def test_orthonormality(Spectrum, spectral_config):
+    spectrum = Spectrum(**spectral_config)
+    eigenfunctions = spectrum.eigenfunction(
+        np.arange(spectral_config["num_lattice_points"]).reshape(-1, 1)
+    )(spectrum.lattice(output_space="real"))
+    assert np.allclose(
+        spectrum.scalar_product(eigenfunctions, eigenfunctions),
+        np.eye(spectral_config["num_lattice_points"]),
+    )
+
+
+@pytest.mark.parametrize(["Spectrum", "spectral_config"], TEST_DATA)
+def test_back_and_forth_transform_is_identity(Spectrum, spectral_config):
+    spectrum = Spectrum(**spectral_config)
+    eigenfunctions = spectrum.eigenfunction(
+        np.arange(spectral_config["num_lattice_points"]).reshape(-1, 1)
+    )(spectrum.lattice(output_space="real"))
+    assert np.allclose(
+        spectrum.transform(
+            spectrum.transform(
+                eigenfunctions, input_space="real", output_space="spectral"
+            ),
+            input_space="spectral",
+            output_space="real",
+        ),
+        eigenfunctions,
+    )


### PR DESCRIPTION
This small PR provides some general tests for the spectra, namely orthonormality of the eigenfunctions (in real space), identity of back and forth transformation and unitarity of the transformation.

These are general properties that hold completely independent of the concrete spectrum at hand (as long as the spectrum's interface is implemented in a way to cope with the terse broadcasting syntax used). So they should be easily generalisable by adding more `TEST_DATA`.

I took the liberty to make the tests pass by adjusting the conventions in `spectra/derivative_1D.py`.