### PR TITLE
Fix dimensionful normalisation

### DIFF
--- a/pseudospectral/spectra/derivative_1D.py
+++ b/pseudospectral/spectra/derivative_1D.py
@@ -14,6 +14,7 @@ class Derivative1D:
     def __init__(self, num_lattice_points, L=1):
         self.num_lattice_points = num_lattice_points
         self.L = L
+        self.a = self.L / self.num_lattice_points
         self.eigenvalues = self._eigenvalues()
 
 
@@ -21,9 +22,7 @@ class Derivative1D:
         """
         Private function to return the eigenfunctions of the 1D derivative operator i.e. exp(ikx)
         """
-        return lambda x: np.exp(self.eigenvalues[index] * x) / np.sqrt(
-            self.num_lattice_points
-        )
+        return lambda x: np.exp(self.eigenvalues[index] * x) / np.sqrt(self.L)
 
     def _eigenvalues(self):
         """
@@ -84,4 +83,4 @@ class Derivative1D:
         # (that's why rhs @ lhs and not lhs @ rhs).
         # Furthermore, the @ operator interpretes multi-dimensional objects as "stacks of matrices"
         # and accordingly acts on the LAST index of the first but the SECOND TO LAST index of the second.
-        return rhs @ lhs.transpose(-1, -2).conjugate()
+        return rhs @ lhs.transpose(-1, -2).conjugate() * self.a


### PR DESCRIPTION
I stumbled across the need for normalisation in #12's [test_real_basis.py](https://github.com/Mayank447/Pseudo-Spectral-Discretization/blob/83fe13558a7bfebe3b0890a3f18fc1284c72fbd4/test/test_real_basis.py#L8) and that shouldn't be necessary. Turns out I'm really not used to working with dimensionful quantities. Here's the fix. With this correct normalisation of the eigenfunctions, the manual normalisation in `test_real_basis.py` is no longer necessary.