### PR TITLE
Fix dimensionful formulae

### DIFF
--- a/pseudospectral/spectra/derivative_1D.py
+++ b/pseudospectral/spectra/derivative_1D.py
@@ -27,7 +27,6 @@ class Derivative1D:
         """
         return 2j * np.pi * (np.fft.fftfreq(self.num_lattice_points, d=self.a))
 
-
     def eigenfunction(self, index: np.ndarray):
         """
         Function to return the eigenfunctions of the 1D derivative operator i.e. exp(ikx)
@@ -38,8 +37,7 @@ class Derivative1D:
             raise ValueError("Index out of bounds for the eigenfunction.")
 
         else:
-            return lambda x: np.exp(self.eigenvalues[index] * x) / np.sqrt(self.num_lattice_points)
-
+            return lambda x: np.exp(self.eigenvalues[index] * x) / np.sqrt(self.L)
 
     def transform(self, input_vector, input_basis, output_basis):
         """
@@ -51,11 +49,11 @@ class Derivative1D:
 
         # Perform the discrete Fast Fourier transform to go from real to spectral space
         elif input_basis == "real" and output_basis == "spectral":
-            return scipy.fft.fft(input_vector, norm="ortho")
+            return scipy.fft.fft(input_vector, norm="ortho") * np.sqrt(self.a)
 
         # Perform the inverse discrete Fast Fourier transform to go from spectral to real space
         elif input_basis == "spectral" and output_basis == "real":
-            return scipy.fft.ifft(input_vector, norm="ortho")
+            return scipy.fft.ifft(input_vector, norm="ortho") / np.sqrt(self.a)
 
         else:
             raise ValueError(f"Unsupported space transformation from {input_basis} to {output_basis}.")
@@ -99,4 +97,4 @@ class Derivative1D:
         # (that's why rhs @ lhs and not lhs @ rhs).
         # Furthermore, the @ operator interpretes multi-dimensional objects as "stacks of matrices"
         # and accordingly acts on the LAST index of the first but the SECOND TO LAST index of the second.
-        return rhs @ lhs.transpose(-1, -2).conjugate()
+        return rhs @ lhs.transpose(-1, -2).conjugate() * self.a

--- a/test/test_spectra.py
+++ b/test/test_spectra.py
@@ -29,13 +29,15 @@ def test_back_and_forth_transform_is_identity(spectrum, eigenfunctions):
 
 
 def test_unitary_transform(spectrum, eigenfunctions):
-    after_transform = spectrum.transform(eigenfunctions, input_basis="real", output_basis="spectral")
+    # The transformation can only ever be unitary if we choose a dimensionless formulation.
+    if np.isclose(spectrum.a, 1):
+        after_transform = spectrum.transform(eigenfunctions, input_basis="real", output_basis="spectral")
 
-    # It suffices to test the forward transformation because if the forward
-    # transformation is unitary and the other test ensures that back and forth
-    # transformation is an identity, we can conclude that the inverse
-    # transformation is also unitary.
-    assert np.allclose(
-        spectrum.scalar_product(after_transform, after_transform, input_basis="spectral"),
-        spectrum.scalar_product(eigenfunctions, eigenfunctions),
-    )
+        # It suffices to test the forward transformation because if the forward
+        # transformation is unitary and the other test ensures that back and forth
+        # transformation is an identity, we can conclude that the inverse
+        # transformation is also unitary.
+        assert np.allclose(
+            spectrum.scalar_product(after_transform, after_transform, input_basis="spectral"),
+            spectrum.scalar_product(eigenfunctions, eigenfunctions),
+        )


### PR DESCRIPTION
Re-opening of #19. Here again the reasoning from the comment there:

Our eigenfunctions have the form
```math
\left\langle x \mid p \right\rangle = Ce^{ipx}
```
for some yet to determine normalisation constant $C$. Now, we want
```math
1 = \left\langle p \mid p \right\rangle = |C|^2 \int_0^L \mathrm{d}x\; e^{-ipx}e^{ipx} = C^2 L \quad \Leftrightarrow |C| = \frac{1}{\sqrt{L}}
```
This fixes the normalisation of the continuum eigenfunctions. Now, the weight in the quadrature could be computed from the general formulae but is quite simply guessed if you just approximate the integral by a Riemann sum:
```math
\int_0^L\mathrm{d}x\; \dots \longrightarrow \sum_{i=0}^{N-1}\Delta x \; \dots
```

Expansion:

The missing piece in the old version was the following: The FFT (with `norm='ortho'`) projects onto a basis with $C = 1/\sqrt{N}$, so assumes $\Delta x = 1$. So, if given a periodic function $f:[0,L]\to C$ we have
```math
f(x) = \sum_p \left\langle x\mid p \right\rangle\left\langle p \mid f\right\rangle = \frac{1}{\sqrt{L}}\sum_p e^{ipx} f_p
```
while the inverse FFT convention yields
```math
f(x) = \frac{1}{\sqrt{N}}\sum_p e^{ipx} f_p
```
and we can see that we lack a factor of $1/\sqrt{\Delta x}$ because $L = N\Delta x$. The factor for the forward transformation is obviously the inverse because
```math
\mathrm{FT}^{-1} = \frac{1}{\sqrt{\Delta x}} \mathrm{FFT}^{-1} \quad \Rightarrow \quad \mathrm{FT} = \left(\frac{1}{\sqrt{\Delta x}}\right)^{-1} \mathrm{FFT}
```
In particular, we can see that we can only ever get a unitary transformation if $\Delta x=1$.

Please review and merge at your earliest convenience.