### PR TITLE
Add twisted boundary conditions for 2D

### DIFF
--- a/pseudospectral/spectra/derivative1D.py
+++ b/pseudospectral/spectra/derivative1D.py
@@ -18,9 +18,9 @@ class Derivative1D:
     def __init__(self, total_num_lattice_points, L=1.0, theta=0.0):
         self.total_num_lattice_points = total_num_lattice_points
         self.total_num_of_dof = self.total_num_lattice_points
-        self.L = L
+        self.L = np.asarray(L)
         self.a = L / total_num_lattice_points
-        self.theta = theta
+        self.theta = np.asarray(theta)
 
     @property
     def spacetime_dimension(self):

--- a/pseudospectral/spectra/fermion2D.py
+++ b/pseudospectral/spectra/fermion2D.py
@@ -72,6 +72,17 @@ class FreeFermion2D:
             )
         )
 
+        self.boundary_conditions = np.prod(
+            np.exp(
+                -I2PI
+                * (self.theta / self.L).reshape(
+                    -1, *(np.ones(self.spacetime_dimension, dtype=int))
+                )
+                * self.x
+            ),
+            axis=0,
+        )
+
     def _setup_spinor_structure(self):
         """
         This includes the gamma matrices, dof_spinor and total_num_of_dof.
@@ -172,7 +183,8 @@ class FreeFermion2D:
 
         elif input_basis == "real" and output_basis == "spectral":
             input_in_momentum_space = np.fft.fftn(
-                input_vector.reshape(-1, *self.num_points, self.dof_spinor),
+                self.boundary_conditions.reshape(1, *self.num_points, 1)
+                * input_vector.reshape(-1, *self.num_points, self.dof_spinor),
                 axes=1 + np.arange(self.spacetime_dimension),
                 norm="ortho",
             ) * np.sqrt(self.volume_element)

--- a/pseudospectral/spectra/fermion2D.py
+++ b/pseudospectral/spectra/fermion2D.py
@@ -27,13 +27,13 @@ class FreeFermion2D:
         m: mass parameter
     """
 
-    def __init__(self, num_points, *, L=None, mu=0, m=0):
-        self._initialise_members(num_points, L, mu, m)
+    def __init__(self, num_points, *, L=None, theta=None, mu=0, m=0):
+        self._initialise_members(num_points, L, theta, mu, m)
         self._setup_spinor_structure()
         self._compute_grids()
         self._solve_spectral_problem_in_spinor_space()
 
-    def _initialise_members(self, num_points, L, mu, m):
+    def _initialise_members(self, num_points, L, theta, mu, m):
         """
         Please, note that some derived quantities like self.dof_spinor are computed
         later!
@@ -42,6 +42,9 @@ class FreeFermion2D:
         self.m = m
         self.num_points = np.asarray(num_points)
         self.L = np.asarray(L) if L is not None else self.num_points
+        self.theta = (
+            np.asarray(theta) if theta is not None else np.zeros_like(self.num_points)
+        )
         self.a = self.L / self.num_points
         self.spacetime_dimension = len(self.num_points)
         self.vol = np.prod(self.L)

--- a/pseudospectral/spectra/fermion2D.py
+++ b/pseudospectral/spectra/fermion2D.py
@@ -62,7 +62,12 @@ class FreeFermion2D:
         )
         self.p = I2PI * np.array(
             np.meshgrid(
-                *(np.fft.fftfreq(n, a) for n, a in zip(self.num_points, self.a)),
+                *(
+                    np.fft.fftfreq(n, a) + t / length
+                    for n, a, t, length in zip(
+                        self.num_points, self.a, self.theta, self.L
+                    )
+                ),
                 indexing="ij",
             )
         )

--- a/pseudospectral/spectra/fermion2D.py
+++ b/pseudospectral/spectra/fermion2D.py
@@ -204,7 +204,8 @@ class FreeFermion2D:
                 input_vector.reshape(-1, np.prod(self.num_points), self.dof_spinor),
             )
             return (
-                np.fft.ifftn(
+                self.boundary_conditions.reshape(1, *self.num_points, 1).conjugate()
+                * np.fft.ifftn(
                     input_in_uniform_spinor_basis.reshape(
                         -1, *self.num_points, self.dof_spinor
                     ),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,6 +17,26 @@ SPECTRA = [
         "type": FreeFermion2D,
         "config": {"num_points": [3, 70], "L": [2, 7], "mu": 0, "m": 0},
     },
+    {
+        "type": FreeFermion2D,
+        "config": {
+            "num_points": [3, 3],
+            "L": [1, 1],
+            "mu": 0,
+            "m": 0,
+            "theta": [0.5, 0.0],
+        },
+    },
+    {
+        "type": FreeFermion2D,
+        "config": {
+            "num_points": [3, 70],
+            "L": [2, 7],
+            "mu": 0,
+            "m": 0,
+            "theta": [0.3, 0.8],
+        },
+    },
 ]
 
 SPECTRA += [spec | {"type": naive_implementation_of(spec["type"])} for spec in SPECTRA]

--- a/test/test_boundary_conditions.py
+++ b/test/test_boundary_conditions.py
@@ -1,48 +1,4 @@
-from pseudospectral import Derivative1D, FreeFermion2D
-import pytest
 import numpy as np
-
-SPECTRA = [
-    {"type": Derivative1D, "config": {"total_num_lattice_points": 3}},
-    {"type": Derivative1D, "config": {"total_num_lattice_points": 101}},
-    {"type": Derivative1D, "config": {"total_num_lattice_points": 3, "L": 3}},
-    {"type": Derivative1D, "config": {"total_num_lattice_points": 101, "L": 42}},
-    {"type": Derivative1D, "config": {"total_num_lattice_points": 3, "theta": 0.1}},
-    {"type": Derivative1D, "config": {"total_num_lattice_points": 101, "theta": 0.3}},
-    {
-        "type": Derivative1D,
-        "config": {"total_num_lattice_points": 3, "L": 3, "theta": 0.5},
-    },
-    {
-        "type": Derivative1D,
-        "config": {"total_num_lattice_points": 101, "L": 42, "theta": 0.8},
-    },
-    {
-        "type": FreeFermion2D,
-        "config": {
-            "num_points": [3, 3],
-            "L": [1, 1],
-            "theta": [0.0, 0.0],
-            "mu": 0,
-            "m": 0,
-        },
-    },
-    {
-        "type": FreeFermion2D,
-        "config": {
-            "num_points": [3, 3],
-            "L": [1, 1],
-            "theta": [0.5, 0.2],
-            "mu": 0,
-            "m": 0,
-        },
-    },
-]
-
-
-@pytest.fixture(params=SPECTRA)
-def spectrum(request):
-    return request.param["type"](**request.param["config"])
 
 
 def test_eigenfunctions_obey_boundary_conditions(spectrum):

--- a/test/test_boundary_conditions.py
+++ b/test/test_boundary_conditions.py
@@ -27,6 +27,16 @@ SPECTRA = [
             "m": 0,
         },
     },
+    {
+        "type": FreeFermion2D,
+        "config": {
+            "num_points": [3, 3],
+            "L": [1, 1],
+            "theta": [0.5, 0.2],
+            "mu": 0,
+            "m": 0,
+        },
+    },
 ]
 
 

--- a/test/test_boundary_conditions.py
+++ b/test/test_boundary_conditions.py
@@ -26,9 +26,7 @@ def spectrum(request):
 
 
 def test_eigenfunctions_obey_boundary_conditions(spectrum):
-    eigenfunctions = spectrum.eigenfunction(
-        np.arange(spectrum.total_num_lattice_points)
-    )
+    eigenfunctions = spectrum.eigenfunction(np.arange(spectrum.total_num_of_dof))
     assert np.allclose(
         np.exp(2.0j * np.pi * spectrum.theta) * eigenfunctions(*spectrum.lattice()),
         eigenfunctions(spectrum.lattice()[0] + spectrum.L),
@@ -36,19 +34,17 @@ def test_eigenfunctions_obey_boundary_conditions(spectrum):
 
 
 def test_inverse_transform_results_in_eigenfunction(spectrum):
-    spectral_representation = np.eye(spectrum.total_num_lattice_points)
+    spectral_representation = np.eye(spectrum.total_num_of_dof)
     real_space_representation = spectrum.transform(
         spectral_representation, "spectral", "real"
     )
-    eigenfunction = spectrum.eigenfunction(np.arange(spectrum.total_num_lattice_points))
+    eigenfunction = spectrum.eigenfunction(np.arange(spectrum.total_num_of_dof))
     assert np.allclose(eigenfunction(*spectrum.lattice()), real_space_representation)
 
 
 def test_transform_with_correct_boundary_conditions(spectrum):
-    eigenfunctions = spectrum.eigenfunction(
-        np.arange(spectrum.total_num_lattice_points)
-    )
+    eigenfunctions = spectrum.eigenfunction(np.arange(spectrum.total_num_of_dof))
     assert np.allclose(
         spectrum.transform(eigenfunctions(*spectrum.lattice()), "real", "spectral"),
-        np.eye(spectrum.total_num_lattice_points),
+        np.eye(spectrum.total_num_of_dof),
     )


### PR DESCRIPTION
Just what it says.

As a first step, the `Derivative1D` code needed a tiny bit of updating to better conform to the interface of `FreeFermion2D` such that I could re-use the tests.